### PR TITLE
Treat the Gauge32 type as a non-negative integer.

### DIFF
--- a/braaasn.c
+++ b/braaasn.c
@@ -661,10 +661,10 @@ void braa_ASNObject_ToString(struct braa_asnobject * obj, unsigned char * buffer
 			snprintf(buffer, size, "%llu", *((u_int64_t*) obj->pdata));
 			break;
 		case BRAAASN_INTEGER:
-		case BRAAASN_GAUGE:
 			snprintf(buffer, size, "%d", obj->ldata);
 			break;
 		case BRAAASN_COUNTER:
+		case BRAAASN_GAUGE:
 		case BRAAASN_TIMETICKS:
 			snprintf(buffer, size, "%u", obj->ldata);
 			break;


### PR DESCRIPTION
I just saw _braa_ return a negative value for a Gauge32 variable, which should be a [non-negative](https://tools.ietf.org/html/rfc2578#section-7.1.7) integer. I patched it to display the _BRAAASN_GAUGE_ type as an unsigned integer.