### PR TITLE
Fix reported delay

### DIFF
--- a/queries.c
+++ b/queries.c
@@ -539,7 +539,7 @@ int bapp_processmessages(int s, struct queryhash *qh, int hexdump)
 			resp = braa_PDUMsg_GetRequestID(ao);
 
 			secd = (tv.tv_sec % 64) - (((resp >> 8) & 0xffff) / 1000);
-			if(secd < 0) secd = 64 - secd;
+			if(secd < 0) secd = 64 + secd; //secd is negative
 			delay = secd * 1000 + (tv.tv_usec / 1000) - (((resp >> 8) & 0xffff) % 1000);
 
 			error = braa_PDUMsg_GetErrorCode(ao);


### PR DESCRIPTION
Query response time is inaccurate when it is over 1 second