### PR TITLE
Manual page for braa

### DIFF
--- a/braa.1
+++ b/braa.1
@@ -1,0 +1,86 @@
+.TH BRAA 1
+.SH NAME
+braa \- Mass SNMP scanner
+.SH SYNOPSIS
+\fBbraa\fR
+\fR[\fB\-h\fR]
+\fR[\fB\-2\fR]
+\fR[\fB\-v\fR]
+\fR[\fB\-t\fR \fI<s>\fR]
+\fR[\fB\-f\fR \fI<file\fR]
+\fR[\fB\-a\fR \fI<time>\fR]
+\fR[\fB\-r\fR \fI<retries>\fR]
+\fR[\fB\-d\fR \fI<delay>\fR]
+\fR[\fB\querylist1\fR]
+\fR[\fB\querylist2\fR]
+\fR[\fB\...\fR]
+.SH DESCRIPTION
+.PP
+  Braa is a mass snmp scanner. The intended usage of such a tool is of course making SNMP queries - but unlike snmpget or snmpwalk from net-snmp, it is able
+to query dozens or hundreds of hosts simultaneously, and in a single process.
+Thus, it consumes very few system resources and does the scanning VERY fast.
+.br
+  Braa implements its OWN snmp stack, so it does NOT need any SNMP libraries like net-snmp. The implementation is very dirty, supports only several data
+types, and in any case cannot be stated 'standard-conforming'! It was designed to be fast, and it is fast. For this reason (well, and also because of my
+laziness ;), there is no ASN.1 parser in braa - you HAVE to know the numerical values of OID's (for instance .1.3.6.1.2.1.1.5.0 instead of system.sysName.0).
+.SH OPTIONS
+.TP
+.B \-h
+Show help.
+.TP
+.B \-2 
+Claim to be a SNMP2C agent.
+.TP
+.B \-v 
+Show short summary after doing all queries.
+.TP
+.B \-x 
+Hexdump octet-strings
+.TP
+.B \-t <s>  
+Wait <s> seconds for responses.
+.TP
+.B \-d <s>
+Wait <s> microseconds after sending each packet.
+.TP
+.B \-p <s>
+Wait <s> milliseconds between subsequent passes.
+.TP
+.B \-f <file>
+Load queries from file <file> (one by line).
+.TP
+.B \-a <time>
+Quit after <time> seconds, independent on what happens.
+.TP
+.B \-r <rc>   
+Retry count (default: 3).
+.SH QUERY FORMATS
+.TP
+.B GET:   [community@]iprange[:port]:oid[/id]
+.TP
+.B  WALK:  [community@]iprange[:port]:oid.*[/id]
+.TP
+.B  SET:   [community@]iprange[:port]:oid=value[/id]
+.SH EXAMPLES
+.TP
+.EX
+.B $ braa public@10.253.101.1:161:.1.3.6.*
+Walk the SNMP tree of host 10.253.101.1 with public string querying all OIDs under .1.3.6:
+.EE
+.TP
+.EX
+.B $ braa 10.253.101.1-10.253.101.254:.1.3.6.1.2.1.1.6.0
+Query the whole subnet 10.53.101/24 of for system.sysLocation.0
+.EE
+.TP
+.EX
+.B $ braa private@10.253.101.1:.1.3.6.1.2.1.1.6.0=sMy network
+Tries to set the value of system.sysLocation.0 to "My network" at host 10.253.101.1
+.EE
+.SH BUGS AND LIMITATIONS
+.IP *
+The only supported datatypes are: integer (gauge, counter, timeticks, etc.) counter64, string, ipaddress, OID. Of course you are free to modify braaasn.c/braaasn.h to support more types...
+.IP *
+braa will never send more than 1500 bytes (or a single packet) to a host in a single try. Thus the number of queries that might be sent to a single host is limited. Additionally, if you reach the limit by specifying too many queries, braa will terminate the whole scanning process... I can't tell what the limit exactly is, it just depends on many factors (mainly, the length of OIDs), anyway, 15 queries per hosts sounds dangerous, and better try not to exceed this number.
+.IP *
+It is impossible to specify FQDN hostnames - you always have to give IP addresses of hosts... well, I think it'll be corrected in future versions, if there will be ones.


### PR DESCRIPTION
This man page was written for inclusion in the Debian package to comply with its standards (all binaries must have a corresponding man page). You may want to include it in your package.